### PR TITLE
Refactor Imu method get_last_valid_orientation

### DIFF
--- a/classes/Imu.py
+++ b/classes/Imu.py
@@ -83,11 +83,15 @@ class Imu:
         return test_dict
 
 
-    def get_last_valid_orientation(self, orientation_data: dict) -> dict:
+    def get_last_valid_orientation(self) -> dict:
+        
         """Get Last Valid Orientation
         Gets the last valid set of orientation data from the orientation dictionary
         @return: dict: data containing the last valid orientations data
         """
+
+        orientation_data = self.get_last_orientation();
+
         i = 0
         while (i < 10):
             if(orientation_data['valid_heading'][0][9 - i] == 1 and orientation_data['valid_orientation'][0][9 - i] == 1):

--- a/main.py
+++ b/main.py
@@ -33,9 +33,8 @@ if __name__ == "__main__":
     # If test flag set
     if (args['t']):
         imu = Imu("./test/mocks/IMU_timestamped_test_data.bin")
-        data = imu.get_last_orientation()
-        valid = imu.get_last_valid_orientation(data)
-        print("\nIMU Test Resultes:")
+        valid = imu.get_last_valid_orientation()
+        print("IMU Test Resultes:")
         print(valid)
     else: 
         imu = Imu(args['imu'])


### PR DESCRIPTION
now get_last_valid_orientation just makes an internal call to get_last_orientation instead of having to be passed the results of the other method